### PR TITLE
Documentation: add redis-server as prerequisite, remove some trailing spaces.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The JavaScript community chat.
 
 ## Installation
 Prerequisites:
+  - `redis-server` ([Installation instructions](http://redis.io/topics/quickstart))
   - `node` ~ `0.10.17`
   - `npm` ~ `1.3.8`
 

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -14,7 +14,7 @@ module.exports = function(grunt){
   grunt.registerTask('run', function(){
     require("./server.js");
   });
-  
+
   grunt.registerTask('test', ['run','mochaTest']);
 
   grunt.registerTask('default', 'test');

--- a/tests/integration/authentication.spec.js
+++ b/tests/integration/authentication.spec.js
@@ -22,11 +22,11 @@ describe("github authenticattion", function(){
       done();
     }
   })
-  
+
   it("works!", function(done){
     done()
   });
-  
+
   //todo write test for socket authentication
   describe("GET /api/me endoint returns user profile", function(){
     var profile, socket;

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -77,8 +77,8 @@ module.exports = function(){
     request.get('http://127.0.0.1:8080/auth/github/callback?code=450bab02b3f9bf0dfd44', {jar: u}, cb);
     return u;
   }
-  
-  
+
+
   function setUpAuthMock(user){
     nock('https://github.com:443')
       .post('/login/oauth/access_token', "grant_type=authorization_code&redirect_uri=http%3A%2F%2F127.0.0.1%3A8080%2Fauth%2Fgithub%2Fcallback&client_id=0bb5305f1db7d2816fa3&client_secret=32d469aa1334e0a29caac7a20054fa57c0c26088&type=web_server&code=450bab02b3f9bf0dfd44")
@@ -88,7 +88,7 @@ module.exports = function(){
         'cache-control': 'private, max-age=0, must-revalidate',
         'strict-transport-security': 'max-age=2592000',
         'x-frame-options': 'deny',
-        'set-cookie': 
+        'set-cookie':
         [ 'logged_in=no; domain=.github.com; path=/; expires=Tue, 06-Sep-2033 19:03:42 GMT; secure; HttpOnly',
           'dotcom_user=; path=/; expires=Thu, 01-Jan-1970 00:00:00 GMT',
           '_gh_sess=BAh7BjoPc2Vzc2lvbl9pZCIlOTdhYjgyNDU4ZDVkOWM4NzM5NGMxYWMwOTlmMTE2NzM%3D--8fe8511ecbfa197eacb96940fb9a66261d10c57a; path=/; expires=Sun, 01-Jan-2023 00:00:00 GMT; secure; HttpOnly' ],


### PR DESCRIPTION
To fix `global redis errorError: Redis connection to localhost:6379 failed - connect ECONNREFUSED` while running watch task and I assume, all other stuff. :smile: 
