### PR TITLE
Fix layout break because of single letter typo

### DIFF
--- a/client/reacts/ChatRoom.js
+++ b/client/reacts/ChatRoom.js
@@ -102,7 +102,7 @@ module.exports = React.createClass({
     <div className="container">
       <div className="row">
         <ContactList rooms={this.props.rooms} room={this.props.room} me={this.props.me} />
-        <div className="chat col-md-9 com-sm-7">
+        <div className="chat col-md-9 col-sm-7">
           <div>{this.props.room.get('name')} {this.leaveJoinButton()}</div>
           <ParticipantsList room={this.props.room}/>
           <ScrollingList 


### PR DESCRIPTION
Change class name so layout doesn't break on small breakpoint.
