### PR TITLE
fix failing spec

### DIFF
--- a/src/socket/flows/room.js
+++ b/src/socket/flows/room.js
@@ -96,16 +96,12 @@ function createRoom(socket, data, next){
 }
 
 function readRooms(socket, data, next){
-  Room.getLastActive(gotLastActive);
-  
-  function gotLastActive(err, results){
-    Room.get({ids: results}, function(err, rooms) {
-      if(err){
-        return next(err);
-      }
-      socket.json(rooms);
-    });
-  }
+  Room.get({ids: data.ids}, function(err, rooms) {
+    if(err){
+      return next(err);
+    }
+    socket.json(rooms);
+  });
 }
 
 function readRoomsByOwner(socket, data,next) {

--- a/tests/integration/chat.rooms.spec.js
+++ b/tests/integration/chat.rooms.spec.js
@@ -138,15 +138,14 @@ describe("Socket based authenticate users", function(){
       before(function(done){
         async.each(rooms, function(item, cb){
           var mock = _(roomMock).extend({name : item});
-          sock1.serve('CREATE /api/rooms', mock, function(err, data){
-            roomIds.push(data);
+          sock1.serve('CREATE /api/rooms', mock, function(err, id){
+            roomIds.push(id);
             cb();
           });
         }, done);
       });
-      // for some reason this fails on travis
-      // TODO: fix
-      xdescribe("Should be able to get all the rooms of mine", function(){
+
+      describe("Should be able to get all the rooms of mine", function(){
         var gotRooms;
         before(function(done){
           sock1.serve('READ /api/rooms', {ids: roomIds}, function(err, data){


### PR DESCRIPTION
We tried to read from range of 'c:r:last' (Last active) though they're being set only when message is sent. And that wasn't fulfilled for stub rooms that were created in before hook.
