### PR TITLE
Skip adding skype smile & emojis for <pre> & <code> text

### DIFF
--- a/client/filters/breakOnText.js
+++ b/client/filters/breakOnText.js
@@ -1,0 +1,32 @@
+// returns arrays of strings, break on pairs of %tag%s
+module.exports = function (tag) {
+  var openning = "<" + tag + ">"
+  var closing = "</" + tag + ">"
+  return function (text) {
+    if (!text || !text.match(openning)) { return [text]; }
+    var strings = []
+    var keyPoints = getOccurences(RegExp(openning), text).concat(getOccurences(RegExp(closing), text, true)).sort(function (self, other) {return self - other});
+    if (keyPoints[0] !== 0) {strings.push(text.slice(0, keyPoints[0]))}
+    for (var i = 0; i < keyPoints.length - 1; i += 1) {
+      strings.push(text.slice(keyPoints[i], keyPoints[i+1]))
+    }
+    if (keyPoints[i] !== text.length) { strings.push(text.slice(keyPoints[keyPoints.length - 1])) }
+    return strings;
+  }
+}
+
+/**
+ * Function to get indexes of certain regexp occurences
+ * @param  {RegExp}     regexp    RegExp to match against
+ * @param  {String}     text      String to be searched
+ * @param  {Booleanish} lastIndex Whether first or last index should be returned
+ * @return {Array}                Array of indexes
+ */
+function getOccurences(regexp, text, lastIndex) {
+  var localRegExp = new RegExp(regexp.source, 'g')
+  var res = [], match;
+  while ((match = localRegExp.exec(text)) !== null) {
+    res.push(lastIndex ? localRegExp.lastIndex : localRegExp.lastIndex - match[0].length)
+  }
+  return res;
+}

--- a/client/filters/breakOnText.spec.js
+++ b/client/filters/breakOnText.spec.js
@@ -1,0 +1,55 @@
+var breakOnText = require('./breakOnText');
+
+describe('skipPre', function(){
+  beforeEach(function(){
+    skipPre = breakOnText('pre')
+  })
+  it('should be defined', function () {
+    expect(skipPre).to.be.a('function');
+  })
+  it('should return regular string if no pre present', function () {
+    expect(skipPre('No pre here')).to.eql(['No pre here'])
+  })
+  describe('should return array of string, pre & not separated', function () {
+    it('Given string starts with pre', function () {
+      expect(skipPre('<pre>Text here</pre>Lol')).to.eql(['<pre>Text here</pre>', 'Lol'])
+    })
+    it('Given string starts & ends with pre', function () {
+      expect(skipPre('<pre>Text here</pre>Lol<pre>Text here</pre>')).to.eql(['<pre>Text here</pre>', 'Lol', '<pre>Text here</pre>'])
+    })
+    it('Given string has one occurence in the middle', function () {
+      expect(skipPre('asdf s<pre>Text here</pre> Lol<pre>Text here</pre>')).to.eql(['asdf s', '<pre>Text here</pre>', ' Lol', '<pre>Text here</pre>'])
+    })
+    it('Given multiple occurencies in the middle', function () {
+      expect(skipPre('asdf s<pre>Text here</pre> Lol<pre>Text here</pre> asdfasdf ')).to.eql(['asdf s', '<pre>Text here</pre>', ' Lol', '<pre>Text here</pre>', ' asdfasdf '])
+    })
+  })
+
+})
+
+describe('skipCode', function(){
+  beforeEach(function(){
+    skipCode = breakOnText('code')
+  })
+  it('should be defined', function () {
+    expect(skipCode).to.be.a('function');
+  })
+  it('should return regular string if no code codesent', function () {
+    expect(skipCode('No code here')).to.eql(['No code here'])
+  })
+  describe('should return array of string, code & not separated', function () {
+    it('Given string starts with code', function () {
+      expect(skipCode('<code>Text here</code>Lol')).to.eql(['<code>Text here</code>', 'Lol'])
+    })
+    it('Given string starts & ends with code', function () {
+      expect(skipCode('<code>Text here</code>Lol<code>Text here</code>')).to.eql(['<code>Text here</code>', 'Lol', '<code>Text here</code>'])
+    })
+    it('Given string has one occurence in the middle', function () {
+      expect(skipCode('asdf s<code>Text here</code> Lol<code>Text here</code>')).to.eql(['asdf s', '<code>Text here</code>', ' Lol', '<code>Text here</code>'])
+    })
+    it('Given multiple occurencies in the middle', function () {
+      expect(skipCode('asdf s<code>Text here</code> Lol<code>Text here</code> asdfasdf ')).to.eql(['asdf s', '<code>Text here</code>', ' Lol', '<code>Text here</code>', ' asdfasdf '])
+    })
+  })
+
+})

--- a/client/filters/filterUtils.js
+++ b/client/filters/filterUtils.js
@@ -1,0 +1,47 @@
+var breakOnPreText = require('./breakOnText')('pre');
+var breakOnCodeText = require('./breakOnText')('code');
+function isPreString(str) {
+  return str.substr(0,5) === '<pre>' || str.substr(-6) === "</pre>"
+}
+function isCodeString(str) {
+  return str.substr(0,6) === '<code>' || str.substr(-7) === "</code>"
+}
+function breakIntoString(text, listOfFuns) {
+  var result = text
+  listOfFuns.forEach(function (splitFn) {
+    if (result instanceof Array ) {
+      result.forEach(function(str, index){
+        [].splice.apply(result, [index, 1].concat(splitFn(str)) )
+      })
+    } else {result = splitFn(result)}
+  })
+  return result
+}
+function makeSkipCodeAndPreformatted(filter) {
+  var splitters = [
+    breakOnPreText,
+    breakOnCodeText
+  ]
+  return function (string) {
+    var filteredStrings = breakIntoString(string, splitters).map(function (str) {
+      if (isPreString(str) || isCodeString(str)) {
+        return str;
+      }
+      return(filter(str));
+    })
+    return filteredStrings.join('')
+  }
+}
+function logify(filter) {
+  return function (str) {
+    console.log('filtering: ', str)
+    return filter(str)
+  }
+}
+module.exports = {
+  makeSkipCodeAndPreformatted: makeSkipCodeAndPreformatted,
+  breakIntoString: breakIntoString,
+  isCodeString: isCodeString,
+  isPreString: isPreString,
+  logify: logify
+}

--- a/client/filters/filterUtils.spec.js
+++ b/client/filters/filterUtils.spec.js
@@ -1,0 +1,30 @@
+var filterUtils = require('./filterUtils')
+var breakOnPreText = require('./breakOnText')('pre');
+var breakOnCodeText = require('./breakOnText')('code');
+describe('breakIntoString', function () {
+  it('should be splitting string by given splitters', function () {
+    var splitters = [
+      breakOnPreText,
+      breakOnCodeText
+    ]
+    var string = '<p>Code is:</p>\n<pre><code>:3\n</code></pre>'
+    expect(filterUtils.breakIntoString(string, splitters)).to.eql([
+      '<p>Code is:</p>\n',
+      '<pre>',
+      '<code>:3\n</code>',
+      '</pre>'
+    ])
+  })
+})
+describe('makeSkipCodeAndPreformatted', function () {
+  it('should not be applying filter to code and pre strings', function () {
+    var dummyFilter = filterUtils.makeSkipCodeAndPreformatted(function(str){return 'X'})
+    var string = '<p>Code is:</p>\n<pre><code>:3\n</code></pre>'
+     expect(dummyFilter(string)).to.eql([
+      'X',
+      '<pre>',
+      '<code>:3\n</code>',
+      '</pre>'
+    ].join(''))
+  })
+})

--- a/client/filters/index.js
+++ b/client/filters/index.js
@@ -1,8 +1,10 @@
+var skipPreCode = require('./filterUtils').makeSkipCodeAndPreformatted
+
 module.exports = [
   require('./escapeFilter.js'),
   require('./youtubeFilter.js'),
   require('./vimeoFilter.js'),
   require('./markdownFilter.js'),
-  require('./skypeEmoticonsFilter.js'),
-  require('./emojiFilter.js')
+  skipPreCode(require('./skypeEmoticonsFilter.js')),
+  skipPreCode(require('./emojiFilter.js'))
 ]


### PR DESCRIPTION
![screenshot from 2014-01-19 17 13 46](https://f.cloud.github.com/assets/1506905/1949729/240e4c94-811d-11e3-8d6f-81274a245aa5.png)
- preventing smiles from being added in `<pre>` & `<code>` text 
- adding filterUtils modules: logify, splitting into lines, breaked by tags etc.
