### PR TITLE
Remove jshint pragmas, add global config - still passing

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,5 @@
+{
+    "browser"       : true,   // Standard browser globals e.g. `window`, `document`.
+    "node"          : true,   // Standard node globals e.g. `module`, `require`.
+    "strict"        : false   // Obey rule to add 'use strict' pragma
+}

--- a/client/services/notification.js
+++ b/client/services/notification.js
@@ -1,6 +1,3 @@
-/* global console, module */
-"use strict";
-
 module.exports = {
   show: function(img, title, text){
     if (!window.webkitNotifications){


### PR DESCRIPTION
There might be an issue for developers who have jshint on by default in their editor (see [this commit](https://github.com/sejoker/jschat/commit/7771bc2a6d91ff5296e8c338feafb62285f1b835) for example), and since there's no hard rules laid out in the project, we can add global variables & ability to pass on 'use strict' for now.
