### PR TITLE
Prevent emojiFilter from failing on ':this is not an emoji:' string

### DIFF
--- a/client/filters/emojiFilter.js
+++ b/client/filters/emojiFilter.js
@@ -11,12 +11,13 @@ function emojifyText(text) {
   var matchName;
   result = result.replace(emojiPresent, function (match) {
     matchName = match.slice(1, -1);
-    return injectEmoji(matchName, match);
+    return injectEmoji(matchName, match) || match;
   })
   return result;
 }
 
 function injectEmoji(name, title){
+  if (!emojis[name]) return null;
   title = title || name;
   return "<img class='emoji' title='"+ title + "'  src='/JSChat/images/emojis/" + name + ".png'/>";
 }


### PR DESCRIPTION
In case string between two semicolons isn't in emoji dictionary, do nothing. Fixes the case of `:this is not an emoji:` turning into broken markup.
